### PR TITLE
Serialize function values as "unserializable"

### DIFF
--- a/src/annotate.js
+++ b/src/annotate.js
@@ -5,7 +5,7 @@ import type { Annotation, Maybe, ObjectAnnotation } from './ast';
 
 export function annotateFields(
     object: { [string]: mixed },
-    fields: Array<[/* key */ string, string | Annotation]>
+    fields: Array<[/* key */ string, string | Annotation]>,
 ): ObjectAnnotation {
     // Convert the object to a list of pairs
     let pairs = Object.entries(object);
@@ -77,6 +77,8 @@ export default function annotate(value: mixed, annotation: Maybe<string>): Annot
             return { type: 'ArrayAnnotation', items, hasAnnotation, annotation };
         } else if (typeof value === 'object') {
             return annotatePairs(Object.entries(value), annotation);
+        } else if (typeof value === 'function') {
+            return { type: 'ScalarAnnotation', value, hasAnnotation: false, annotation };
         } else {
             throw new Error('Unknown annotation');
         }

--- a/src/annotate.js
+++ b/src/annotate.js
@@ -5,7 +5,7 @@ import type { Annotation, Maybe, ObjectAnnotation } from './ast';
 
 export function annotateFields(
     object: { [string]: mixed },
-    fields: Array<[/* key */ string, string | Annotation]>,
+    fields: Array<[/* key */ string, string | Annotation]>
 ): ObjectAnnotation {
     // Convert the object to a list of pairs
     let pairs = Object.entries(object);


### PR DESCRIPTION
The following snippet demonstrates that any Object including a value of a Function will throw an error when attempting to serialize. 

```js
const a = annotate({
    a: function() {
        console.log('hi');
    },
    b: 3,
});

serialize(a); // Throws "Error: Unknown annotation"
```

This does not throw an error if a function is encountered, but marks the value as `(unserializable)`:

```js
const a = annotate({
    a: function() {
        console.log('hi');
    },
    b: 3,
});

serialize(a);  // '{ "a": (unserializable), "b": 3 }'
```